### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that provides a bridge between Figma designs and React implementations. This server enables pixel-perfect conversion of Figma designs into React applications by processing Figma file data and providing it in a React-friendly format.
 
+<a href="https://glama.ai/mcp/servers/@sanjeev23oct/figma-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sanjeev23oct/figma-mcp/badge" alt="Figma Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 - **Figma API Integration**: Direct connection to Figma's API for accessing design files


### PR DESCRIPTION
This PR adds a badge for the [Figma MCP Server](https://glama.ai/mcp/servers/@sanjeev23oct/figma-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sanjeev23oct/figma-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sanjeev23oct/figma-mcp/badge" alt="Figma Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.